### PR TITLE
Fix SonarCloud workflow for PR analysis

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -48,39 +48,56 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve SonarCloud scan parameters
+        id: sonar-params
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BASE_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            echo "args=-Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=$HEAD_BRANCH -Dsonar.pullrequest.base=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "ref=pullRequest=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            ENCODED_REF=$(printf '%s' "$HEAD_BRANCH" | jq -sRr @uri)
+            echo "args=-Dsonar.branch.name=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "ref=branch=$ENCODED_REF" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: SonarCloud Scan
         id: sonarqube-scan
         uses: SonarSource/sonarqube-scan-action@master
+        with:
+          args: ${{ steps.sonar-params.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Resolve SonarCloud ref
-        id: sonar-ref
-        env:
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          if [ "$PR_NUMBER" != "" ]; then
-            echo "ref=pullRequest=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          else
-            ENCODED_REF=$(printf '%s' "$HEAD_BRANCH" | jq -sRr @uri)
-            echo "ref=branch=$ENCODED_REF" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Fail job if Quality Gate fails
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_REF: ${{ steps.sonar-ref.outputs.ref }}
+          SONAR_REF: ${{ steps.sonar-params.outputs.ref }}
         run: |
-          if ! RESPONSE=$(curl --fail --silent \
-            -H "Authorization: Bearer $SONAR_TOKEN" \
-            "https://sonarcloud.io/api/measures/component?metricKeys=alert_status&component=$SONAR_PROJECT_KEY&$SONAR_REF"); then
-            echo "Failed to fetch quality gate status from SonarCloud API"
+          URL="https://sonarcloud.io/api/measures/component?metricKeys=alert_status&component=$SONAR_PROJECT_KEY&$SONAR_REF"
+          for attempt in 1 2 3 4 5; do
+            HTTP_CODE=$(curl --silent --output /tmp/sonar_response.json --write-out '%{http_code}' \
+              -H "Authorization: Bearer $SONAR_TOKEN" "$URL")
+            if [ "$HTTP_CODE" = "200" ]; then
+              break
+            fi
+            echo "Attempt $attempt: HTTP $HTTP_CODE — waiting for SonarCloud to process results..."
+            cat /tmp/sonar_response.json
+            echo ""
+            sleep 15
+          done
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Failed to fetch quality gate after 5 attempts (HTTP $HTTP_CODE)"
+            cat /tmp/sonar_response.json
             exit 1
           fi
 
-          STATUS=$(echo "$RESPONSE" | jq -r '.component.measures[0].value // "ERROR"')
+          STATUS=$(jq -r '.component.measures[0].value // "ERROR"' /tmp/sonar_response.json)
           echo "Quality Gate: ${STATUS}"
           [ "$STATUS" = "OK" ] || { echo "Quality Gate failed with status: $STATUS"; exit 1; }
 
@@ -88,22 +105,16 @@ jobs:
         id: sonarqube-report
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_REF: ${{ steps.sonar-ref.outputs.ref }}
+          SONAR_REF: ${{ steps.sonar-params.outputs.ref }}
         run: |
-          REF="$SONAR_REF"
-
-          if ! DATA=$(curl --fail --silent --request GET \
-            --url "https://sonarcloud.io/api/measures/component?metricKeys=alert_status%2Cbugs%2Ccode_smells%2Ccoverage%2Cduplicated_lines_density%2Cncloc%2Creliability_rating%2Csecurity_rating%2Csqale_index%2Csqale_rating%2Cvulnerabilities&component=$SONAR_PROJECT_KEY&$REF" \
-            --header "Authorization: Bearer $SONAR_TOKEN"); then
-            echo "Failed to fetch metrics from SonarCloud API"
-            exit 1
-          fi
+          URL="https://sonarcloud.io/api/measures/component?metricKeys=alert_status%2Cbugs%2Ccode_smells%2Ccoverage%2Cduplicated_lines_density%2Cncloc%2Creliability_rating%2Csecurity_rating%2Csqale_index%2Csqale_rating%2Cvulnerabilities&component=$SONAR_PROJECT_KEY&$SONAR_REF"
+          DATA=$(curl --fail --silent -H "Authorization: Bearer $SONAR_TOKEN" "$URL")
 
           for metric in alert_status bugs code_smells coverage duplicated_lines_density ncloc reliability_rating security_rating sqale_index sqale_rating vulnerabilities; do
             value=$(echo "$DATA" | jq -r --arg m "$metric" '.component.measures[] | select(.metric == $m) | .value')
             echo "${metric}=${value}" >> "$GITHUB_OUTPUT"
           done
-          echo "git_ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "git_ref=$SONAR_REF" >> "$GITHUB_OUTPUT"
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v3


### PR DESCRIPTION
## Summary

- Moves scan parameter resolution **before** the SonarCloud scan step so it receives `-Dsonar.pullrequest.key/branch/base` args (without these, SonarCloud runs a branch analysis and the quality gate API returns 404 for PR queries)
- Replaces `curl --fail --silent` with a 5-attempt retry loop using `--write-out '%{http_code}'` — SonarCloud results aren't immediately available after scan, and `--fail --silent` swallows HTTP error details

No changes to `test.yml`, `claude-review-pr.yml`, `sonar-project.properties`, or `README.md`.

---

Generated by SS6 Migration Toolkit